### PR TITLE
Delete response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 npm-debug.log
+package-lock.json
 scratch.*
 venv/
 dist/

--- a/app/app-tags.css
+++ b/app/app-tags.css
@@ -59,3 +59,7 @@ input:focus {
 textarea {
   font-family: monospace;
 }
+
+a {
+  margin-right: 10px;
+}

--- a/app/components/AllowEditButton.js
+++ b/app/components/AllowEditButton.js
@@ -30,12 +30,21 @@ export default class extends React.Component {
 
   render () {
     const { showModal, inputText, allowEdit } = this.state
-    const { children, dbName, couchUrl } = this.props
+    const { children, dbName, couchUrl, type, infoMessage } = this.props
     return (
       <span>
-        <button className='action-button edit-button' onClick={this.toggleModal}>
-          {children}
-        </button>
+        {
+          type === 'link'
+          ? (
+            <a href='#' onClick={e => {e.preventDefault(); this.toggleModal()}}>
+              {children}
+            </a>
+          ) : (
+            <button className='action-button edit-button' onClick={this.toggleModal}>
+              {children}
+            </button>
+          )
+        }
         <Modal
           show={showModal}
           onClose={this.toggleModal}
@@ -49,6 +58,11 @@ export default class extends React.Component {
               <strong>{couchUrl}{dbName}</strong>
             </div>
           </div>
+          {infoMessage && (
+            <div>
+              {infoMessage}
+            </div>
+          )}
           <br />
           <form onSubmit={this.onSubmit}>
             <label>

--- a/app/components/AllowEditButton.js
+++ b/app/components/AllowEditButton.js
@@ -35,15 +35,15 @@ export default class extends React.Component {
       <span>
         {
           type === 'link'
-          ? (
-            <a href='#' onClick={e => {e.preventDefault(); this.toggleModal()}}>
-              {children}
-            </a>
-          ) : (
-            <button className='action-button edit-button' onClick={this.toggleModal}>
-              {children}
-            </button>
-          )
+            ? (
+              <a href='#' onClick={e => { e.preventDefault(); this.toggleModal() }}>
+                {children}
+              </a>
+            ) : (
+              <button className='action-button edit-button' onClick={this.toggleModal}>
+                {children}
+              </button>
+            )
         }
         <Modal
           show={showModal}

--- a/app/components/Pagination.js
+++ b/app/components/Pagination.js
@@ -20,7 +20,6 @@ export default class Pagination extends React.Component {
             <Link to={path}>previous</Link>
           )}
           {previousNumber < 0 && 'previous'}
-          &nbsp;
           {offset + displayed < total && (
             <Link to={path + '?offset=' + nextNumber}>next</Link>
           )}

--- a/app/containers/ConfigContainer.js
+++ b/app/containers/ConfigContainer.js
@@ -62,8 +62,8 @@ export default class ConfigContainer extends React.Component {
       <div className='config-container'>
         <Breadcrumbs couch={couch} docId={'_config'} />
         <div className='controls'>
-          <a href='#' onClick={this.download}>download</a> &nbsp;
-          <a href='#' onClick={this.copy}>copy to clipboard</a> &nbsp;
+          <a href='#' onClick={this.download}>download</a>
+          <a href='#' onClick={this.copy}>copy to clipboard</a>
         </div>
         {error && <Error error={error} />}
         {!error && !loaded && (<Loading />)}

--- a/app/containers/DocContainer.js
+++ b/app/containers/DocContainer.js
@@ -69,8 +69,8 @@ export default class extends React.Component {
         {!error && loaded && (
           <div>
             <div className='controls'>
-              <a href='#' onClick={this.download}>download</a> &nbsp;
-              <a href='#' onClick={this.copy}>copy to clipboard</a> &nbsp;
+              <a href='#' onClick={this.download}>download</a>
+              <a href='#' onClick={this.copy}>copy to clipboard</a>
               <AllowEditButton
                 dbName={dbName}
                 couchUrl={couchUrl}

--- a/app/containers/DocsContainer.js
+++ b/app/containers/DocsContainer.js
@@ -64,7 +64,7 @@ export default class extends React.Component {
             <section className='docs-controls'>
               <PaginationComponent />
               <div>
-                <Link to={`/${couch}/${dbName}/query/`}>query</Link> &nbsp;
+                <Link to={`/${couch}/${dbName}/query/`}>query</Link>
                 <AllowEditButton
                   dbName={dbName}
                   couchUrl={couchUrl}

--- a/app/containers/EditDocContainer.js
+++ b/app/containers/EditDocContainer.js
@@ -57,17 +57,16 @@ export default class extends React.Component {
 
   onSubmit = () => {
     const { couchUrl, dbName, couch } = this.props
-    const { input, isNew, docId  } = this.state
+    const { input, isNew } = this.state
 
     const jsObjectInput = JSON.parse(input)
     this.setState({ saving: true }, () => {
       // New documents will get ID from input
       const docId = isNew ? jsObjectInput._id : this.state.docId
       fetcher.dbPut(couchUrl, dbName, docId, jsObjectInput).then(() => {
-        this.setState({ docId }, () => {this.props.history.push(`/${couch}/${dbName}/${docId}`)})
+        this.setState({ docId }, () => { this.props.history.push(`/${couch}/${dbName}/${docId}`) })
       }).catch(error => this.setState({ error, saving: false }))
-    });
-
+    })
   }
 
   deleteDoc = () => {
@@ -91,7 +90,6 @@ export default class extends React.Component {
       this.props.history.push(`/${couch}/${dbName}/${docId}`)
     }
   }
-
 
   render () {
     const { couch, couchUrl, dbName } = this.props

--- a/app/containers/QueryContainer.js
+++ b/app/containers/QueryContainer.js
@@ -138,23 +138,23 @@ export default class QueryContainer extends React.Component {
         queries: {links}
         <br /><br />
         <a href='' onClick={this.copy}>copy response to clipboard</a>
-        &nbsp; <a href='' onClick={e => {e.preventDefault(); this.download()}}>download response</a>
+        &nbsp; <a href='' onClick={e => { e.preventDefault(); this.download() }}>download response</a>
         &nbsp; <a href='' onClick={this.getUrl}>copy sharable url to clipboard</a>
         &nbsp;
-          <AllowEditButton
-            dbName={dbName}
-            type='link'
-            couchUrl={couchUrl}
-            onConfirm={this.handleConfirmDelete}
-            infoMessage={`
+        <AllowEditButton
+          dbName={dbName}
+          type='link'
+          couchUrl={couchUrl}
+          onConfirm={this.handleConfirmDelete}
+          infoMessage={`
               This will {_deleted: true} 'docs' found in the
               response object (not the results of your 'parse' function!).
               It downloads them first, keep that as your backup as couch
               revisions are not guaranteed to stick around.
             `}
-          >
+        >
           delete response
-          </AllowEditButton>
+        </AllowEditButton>
         {loading
           ? <Loading />
           : result &&

--- a/app/containers/QueryContainer.js
+++ b/app/containers/QueryContainer.js
@@ -101,7 +101,7 @@ export default class QueryContainer extends React.Component {
     const response = await fetcher.post(`${dbUrl}_bulk_docs`, {docs})
     console.log(`deleted docs response`, response)
     const errorsFound = response.filter(r => !r.ok)
-    if (errorsFound) {
+    if (errorsFound.length) {
       console.error(`Errors found when trying to delete docs!`, errorsFound)
     }
   }

--- a/app/containers/QueryContainer.js
+++ b/app/containers/QueryContainer.js
@@ -114,7 +114,7 @@ export default class QueryContainer extends React.Component {
 
     const links = Object.keys(queries).map(query => (
       <span key={query}>
-        <Link to={`/${couch}/${dbName}/query/${query}`}>{query}</Link>&nbsp;
+        <Link to={`/${couch}/${dbName}/query/${query}`}>{query}</Link>
       </span>
     ))
     return (
@@ -138,9 +138,9 @@ export default class QueryContainer extends React.Component {
         queries: {links}
         <br /><br />
         <a href='' onClick={this.copy}>copy response to clipboard</a>
-        &nbsp; <a href='' onClick={e => { e.preventDefault(); this.download() }}>download response</a>
-        &nbsp; <a href='' onClick={this.getUrl}>copy sharable url to clipboard</a>
-        &nbsp;
+        <a href='' onClick={e => { e.preventDefault(); this.download() }}>download response</a>
+        <a href='' onClick={this.getUrl}>copy sharable url to clipboard</a>
+
         <AllowEditButton
           dbName={dbName}
           type='link'

--- a/app/containers/QueryContainer.js
+++ b/app/containers/QueryContainer.js
@@ -87,7 +87,9 @@ export default class QueryContainer extends React.Component {
 
   handleConfirmDelete = async () => {
     this.download()
-    const docs = this.state.response.docs.map(doc => ({
+    const {response} = this.state
+    const originalDocs = response.docs || response.rows.map(row => row.doc)
+    const docs = originalDocs.map(doc => ({
       _id: doc._id,
       _rev: doc._rev,
       _deleted: true
@@ -98,9 +100,9 @@ export default class QueryContainer extends React.Component {
       )
     }
     const {dbUrl} = this.props
-    const response = await fetcher.post(`${dbUrl}_bulk_docs`, {docs})
-    console.log(`deleted docs response`, response)
-    const errorsFound = response.filter(r => !r.ok)
+    const deleteResponse = await fetcher.post(`${dbUrl}_bulk_docs`, {docs})
+    console.log(`deleted docs response`, deleteResponse)
+    const errorsFound = deleteResponse.filter(r => !r.ok)
     if (errorsFound.length) {
       console.error(`Errors found when trying to delete docs!`, errorsFound)
     }

--- a/app/utils/queries.js
+++ b/app/utils/queries.js
@@ -88,6 +88,23 @@ export function getAllQueries (dbUrl) {
       },
       startRow: 5,
       startColumn: 25
+    },
+    'bulk-docs': {
+      fetchParams: {
+        url: `${dbUrl}_bulk_docs`,
+        method: 'POST',
+        body: {
+          docs: []
+        }
+      },
+      fn: function parse (response) {
+        // tip: chrome dev tools, right-click on logged object, store as global variable
+        console.log(response)
+        // limit doc length to display so we don't crash the browser
+        return response.slice(0, 50)
+      },
+      startRow: 5,
+      startColumn: 25
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4022,6 +4022,15 @@
         "postcss-value-parser": "^3.2.3"
       }
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -8362,7 +8371,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
       "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
-      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -8371,7 +8379,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -10055,8 +10062,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -11531,8 +11537,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.18.0",
     "protobufjs": "^6.8.8",
     "react": "^16.4.1",
     "react-ace": "^6.1.0",

--- a/scripts/deploy-to-couch.js
+++ b/scripts/deploy-to-couch.js
@@ -1,0 +1,53 @@
+const fs = require('fs')
+const parseArgs = require('minimist')
+const axios = require('axios')
+
+const BUILD_PATH = './dist/'
+
+postDocs(parseArgs(process.argv.slice(2)))
+
+async function postDocs ({
+  couchUrl = 'http://localhost:5984/',
+  databaseName = 'lookout',
+  username = process.env.SCRIPT_USER || 'admin',
+  password = process.env.SCRIPT_PASS || 'admin'
+}) {
+  const url = `${couchUrl}${databaseName}/lookout`
+  const auth = {username, password}
+  const _rev = await getRev(url, auth)
+  const doc = {
+    _id: 'lookout',
+    _rev,
+    _attachments: {
+      'index.html': {
+        content_type: 'text\/html',
+        data: getBase64File('index.html')
+      },
+      'lookout.js': {
+        content_type: 'text\/javascript',
+        data: getBase64File('lookout.js')
+      }
+    }
+  }
+  try {
+    const {data} = await axios.put(url, doc, {auth})
+    console.log(data)
+  } catch (error) {
+    const {status, statusText, data} = error.response
+    console.log(status, statusText, data)
+  }
+}
+
+async function getRev (url, auth) {
+  try {
+    const {data: {_rev}} = await axios.get(url, {auth})
+    return _rev
+  } catch (error) {
+    console.log('no existing doc found.')
+  }
+}
+
+function getBase64File (fileName) {
+  const file = fs.readFileSync(`${BUILD_PATH}/${fileName}`)
+  return file.toString('base64')
+}

--- a/scripts/deploy-to-couch.js
+++ b/scripts/deploy-to-couch.js
@@ -20,11 +20,11 @@ async function postDocs ({
     _rev,
     _attachments: {
       'index.html': {
-        content_type: 'text\/html',
+        content_type: `text\/html`, // eslint-disable-line
         data: getBase64File('index.html')
       },
       'lookout.js': {
-        content_type: 'text\/javascript',
+        content_type: `text\/javascript`, // eslint-disable-line
         data: getBase64File('lookout.js')
       }
     }


### PR DESCRIPTION
This adds two dangerous things to the query page:

1. **delete response** when you do a _find query, you now have the option of deleting the response, which we were doing a lot manually. (a `_deleted: true` delete). it prompts you with a warning first and downloads the data to your system as well before deleting. 

2. **bulk-docs** this "query" is actually just short hand for setting up a post to bulk docs

![Screen Shot 2019-04-11 at 4 48 46 PM](https://user-images.githubusercontent.com/721262/55971743-015abc80-5c7a-11e9-9fb0-bf9df581dffd.png)

there's also a script i use to post lookout to my local couch, which we may want to do some day on some of our envs